### PR TITLE
getallheaders polyfill for nginx and commenting out of shell_exec curl

### DIFF
--- a/getallheaders.php
+++ b/getallheaders.php
@@ -1,0 +1,46 @@
+<?php
+
+if (!function_exists('getallheaders')) {
+
+    /**
+     * Get all HTTP header key/values as an associative array for the current request.
+     *
+     * @return string[string] The HTTP header key/value pairs.
+     */
+    function getallheaders()
+    {
+        $headers = array();
+
+        $copy_server = array(
+            'CONTENT_TYPE'   => 'Content-Type',
+            'CONTENT_LENGTH' => 'Content-Length',
+            'CONTENT_MD5'    => 'Content-Md5',
+        );
+
+        foreach ($_SERVER as $key => $value) {
+            if (substr($key, 0, 5) === 'HTTP_') {
+                $key = substr($key, 5);
+                if (!isset($copy_server[$key]) || !isset($_SERVER[$key])) {
+                    $key = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', $key))));
+                    $headers[$key] = $value;
+                }
+            } elseif (isset($copy_server[$key])) {
+                $headers[$copy_server[$key]] = $value;
+            }
+        }
+
+        if (!isset($headers['Authorization'])) {
+            if (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
+                $headers['Authorization'] = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
+            } elseif (isset($_SERVER['PHP_AUTH_USER'])) {
+                $basic_pass = isset($_SERVER['PHP_AUTH_PW']) ? $_SERVER['PHP_AUTH_PW'] : '';
+                $headers['Authorization'] = 'Basic ' . base64_encode($_SERVER['PHP_AUTH_USER'] . ':' . $basic_pass);
+            } elseif (isset($_SERVER['PHP_AUTH_DIGEST'])) {
+                $headers['Authorization'] = $_SERVER['PHP_AUTH_DIGEST'];
+            }
+        }
+
+        return $headers;
+    }
+
+}

--- a/parserlink.php
+++ b/parserlink.php
@@ -166,9 +166,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 if (!empty($requestStrings)) {
-    if (strpos($requestStrings[0], 'curlorig') === 0) {
+    /*if (strpos($requestStrings[0], 'curlorig') === 0) {
         $curlResponse = shell_exec('curl ' . substr($requestStrings[0], 9)) ?: '';
-    } else if (start_with($requestStrings[0], 'curl')) {
+    } else*/ if (start_with($requestStrings[0], 'curl')) {
         $curlResponse = curl_request(parse_curl_command($requestStrings[0]));
     } else {
         $curlResponse = curl_request(array(

--- a/parserlink.php
+++ b/parserlink.php
@@ -72,6 +72,7 @@ function curl_request($options)
 
     if (curl_errno($ch)) {
         $result = 'Error:' . curl_error($ch);
+        error_log('CURL '.$result);
     }
 
     $content_type = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);

--- a/proxym3u8.php
+++ b/proxym3u8.php
@@ -6,6 +6,8 @@
  * Time: 22:48
  */
 
+require_once('getallheaders.php');
+
 $url = substr($_SERVER['REQUEST_URI'], strlen('/proxym3u8'));
 
 //just for debugging on windows only


### PR DESCRIPTION
1. getallheaders() is available only if PHP is running under Apache. In other cases we need polyfill.

2. shell_exec() is really unsafe thing and in any case "curlorig" is not used by ForkPlayer. So will be better to just remove it.