### PR TITLE
Update plugin.php

### DIFF
--- a/ForkPlayer/Plugins/Local/plugin.php
+++ b/ForkPlayer/Plugins/Local/plugin.php
@@ -60,7 +60,7 @@ class LocalPlugin extends BasePlugin
      */
     private function readDir($context, $basePath) {
         $dir = dir(realpath($basePath));
-
+        $curdir = realpath($dir->path);
         $items = array();
 
         while (false !== ($filename = $dir->read())) {
@@ -83,7 +83,7 @@ class LocalPlugin extends BasePlugin
                         new Item(
                             $filename,
                             '',
-                            $context->getRequest()->absoluteUrl($this->urlRoot . '/' . ($this->relativePath($path))),
+                            $context->getRequest()->absoluteUrl($this->urlRoot . '/' . ($this->relativePath($curdir).'/'.$filename)),
                             '',
                             ItemType::from(ItemType::FILE)
                         )


### PR DESCRIPTION
Fixed bug related to the fact that "relativePath" can't always return the path to a large file (>2gb).
Because of this, the correct file paths were only displayed for small files.
It is checked on a router with Linux.
Bug example:
channels: [
    {
        title: "01 Prescription Murder.mkv",
        stream_url: "http://192.168.1.100:89/localvideo/Columbo/01 Prescription Murder.mkv"
    },
    {
        title: "02 Ransom For A Dead Man",
        stream_url: "http://192.168.1.100:89/localvideo/opt/share/nginx/html/forkplayer"
    },