### PR TITLE
Update parserlink.php

### DIFF
--- a/parserlink.php
+++ b/parserlink.php
@@ -88,6 +88,8 @@ function curl_request($options)
         $result = mb_convert_encoding($result, 'UTF-8', $charset);
     }
 
+    $result = str_replace('#EXTM3U', PHP_EOL.PHP_EOL.'#EXTM3U', $result);
+
     return $result;
 }
 


### PR DESCRIPTION
Fix for Tree.TV and possibly other sources.
Adding \n\n before "#EXTM3U", because in forkplayer.js present this code:

"function tw5(u,sel,mini, pl,yk,title,parse_url,remote,s){
	if(s.indexOf("Connection:")>0&&s.indexOf("Server:")>=0){
		setcook(s);
		var x=s.indexOf("\n\n")+2;"

Decide whether you need to add this to the generic code, or perhaps better come up with another solution.